### PR TITLE
Formula for kapp 0.1.1

### DIFF
--- a/Formula/kapp.rb
+++ b/Formula/kapp.rb
@@ -1,0 +1,19 @@
+class Kapp < Formula
+  desc "Create Go app running in Kubernetes with minimal configuration"
+  homepage "https://github.com/peterj/kapp"
+  url "https://github.com/peterj/kapp/archive/0.1.1.tar.gz"
+  sha256 "8ab28c1f0e7b0b9b47e9f6e2932aef88469874a221e1bd701b2928bdce7b65bf"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    bin_path = buildpath/"src/github.com/peterj/kapp"
+
+    bin_path.install Dir["*"]
+    cd bin_path do
+      system "go", "build", "-o", bin/"kapp", "."
+    end
+  end
+end


### PR DESCRIPTION
Closes #1 

```
johnhobbs@localhost $ brew install Formula/kapp.rb
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core, homebrew/cask).
==> Updated Formulae
go ✔                     carthage                 cpprestsdk               godep                    golang-migrate           node-build               presto                   serverless

==> Installing dependencies for kapp: go
==> Installing kapp dependency: go
==> Downloading https://homebrew.bintray.com/bottles/go-1.11.1.high_sierra.bottle.tar.gz
######################################################################## 100.0%
==> Pouring go-1.11.1.high_sierra.bottle.tar.gz
==> Caveats
A valid GOPATH is required to use the `go get` command.
If $GOPATH is not specified, $HOME/go will be used by default:
  https://golang.org/doc/code.html#GOPATH

You may wish to add the GOROOT-based install location to your PATH:
  export PATH=$PATH:/usr/local/opt/go/libexec/bin
==> Summary
🍺  /usr/local/Cellar/go/1.11.1: 9,279 files, 404MB
==> Installing kapp
==> Downloading https://github.com/peterj/kapp/archive/0.1.1.tar.gz
Already downloaded: /Users/johnhobbs/Library/Caches/Homebrew/downloads/947138e115a781be27ec164fc72e90d229951a02e40b5cb63ea4157daaefca11--kapp-0.1.1.tar.gz
==> go build -o /usr/local/Cellar/kapp/0.1.1/bin/kapp .
🍺  /usr/local/Cellar/kapp/0.1.1: 3 files, 4.3MB, built in 3 seconds
==> Caveats
==> go
A valid GOPATH is required to use the `go get` command.
If $GOPATH is not specified, $HOME/go will be used by default:
  https://golang.org/doc/code.html#GOPATH

You may wish to add the GOROOT-based install location to your PATH:
  export PATH=$PATH:/usr/local/opt/go/libexec/bin
johnhobbs@localhost $ kapp
Create Kubernetes App helps you jump start your Kubernetes services by creating all
necessary files that are need for getting your service up and running in Kubernetes.

Usage:
  kapp [flags]
  kapp [command]

Available Commands:
  create      Creates a new Kubernetes app
  help        Help about any command
  version     Prints the version number

Flags:
  -h, --help      help for kapp
  -v, --verbose   show verbose output

Use "kapp [command] --help" for more information about a command.
johnhobbs@localhost $
```